### PR TITLE
Increased pull-down time for DHT11 sensor to 18 ms.

### DIFF
--- a/dht-sensor.cpp
+++ b/dht-sensor.cpp
@@ -66,7 +66,7 @@ long readDHT(int type, int pin, float &temperature, float &humidity)
     bcm2835_gpio_write(pin, HIGH);
     usleep(10000);
     bcm2835_gpio_write(pin, LOW);
-    usleep(type == 11 ? 2500 : 800);
+    usleep(type == 11 ? 18000 : 800);
     bcm2835_gpio_write(pin, HIGH);
     bcm2835_gpio_fsel(pin, BCM2835_GPIO_FSEL_INPT);
 


### PR DESCRIPTION
Hello,

in this pull request, I increased the pull-down time for the DHT11 sensor to 18 ms(according to the spec sheets). I had the same problem as stated in this issue #67.
Increasing the pull-down time solved the problem for me.

Greetings

Marcel