### PR TITLE
Support for test mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,37 @@ var sensor = {
 sensor.read();
 ```
 
+### Test mode
+
+A *test mode* of operation is available since version `0.2.0`. In this mode of operation, the library does not communicate with the sensor hardware via the **GPIO** but instead it returns a pre-configured readout value. You can use the test mode during development without the need to have an actual sensor connected.
+
+To enable the *test mode*, fake values must be defined at initialization. In the example below we specify fixed values for temperature equal to 21&deg;C and humidity equal to 60%.
+
+```javascript
+sensor.initialize({
+    test : {
+        fake: {
+            temperature: 21,
+            humidity: 60
+        }
+    }
+});
+```
+
+After initialization, we can call the `read` method as usual.
+
+```javascript
+sensor.read(22, 4, function(err, temperature, humidity) {
+    if (!err) {
+        console.log('temp: ' + temperature.toFixed(1) + '°C, ' +
+            'humidity: ' + humidity.toFixed(1) + '%'
+        );
+    }
+});
+```
+And the result will always be the configured readout value defined at initialization. You can find a complete source code example in [examples/fake-test.js](https://github.com/momenso/node-dht-sensor/blob/master/examples/fake-test.js).
+
+
 ### Reference for building from source
 
 Standard node-gyp commands are used to build the module. So, just make sure you have node and node-gyp as well as the Broadcom library to build the project.

--- a/examples/fake-test.js
+++ b/examples/fake-test.js
@@ -1,0 +1,18 @@
+var sensor = require('../build/Release/node_dht_sensor');
+
+sensor.initialize({
+	test : {
+		fake: {
+			temperature: 21,
+			humidity: 60
+		}
+	}
+});
+
+sensor.read(22, 4, function(err, temperature, humidity) {
+    if (!err) {
+        console.log('temp: ' + temperature.toFixed(1) + '°C, ' +
+            'humidity: ' + humidity.toFixed(1) + '%'
+        );
+    }
+});

--- a/examples/fake-test.js
+++ b/examples/fake-test.js
@@ -1,15 +1,15 @@
 var sensor = require('../build/Release/node_dht_sensor');
 
 sensor.initialize({
-	test : {
-		fake: {
-			temperature: 21,
-			humidity: 60
-		}
-	}
+    test: {
+        fake: {
+            temperature: 21,
+            humidity: 60
+        }
+    }
 });
 
-sensor.read(22, 4, function(err, temperature, humidity) {
+sensor.read(22, 4, function (err, temperature, humidity) {
     if (!err) {
         console.log('temp: ' + temperature.toFixed(1) + '°C, ' +
             'humidity: ' + humidity.toFixed(1) + '%'

--- a/test/node-dht-sensor.js
+++ b/test/node-dht-sensor.js
@@ -5,6 +5,18 @@ const SENSOR_TYPE = parseInt(process.env.SENSOR_TYPE || 11, 10);
 const GPIO_PIN = parseInt(process.env.GPIO_PIN || 4, 10);
 
 describe('Initialize', () => {
+    describe('Initialize mock sensor', () => {
+        it('should initialize to provide fake readouts', () => {
+            sensor.initialize({ 
+                test: { 
+                    fake: {
+                        temperature: 42,
+                        humidity: 72
+                    }
+                }
+            });
+        });
+    });
     describe('Sensor type and GPIO pin', () => {
         it('should throw error if sensor type is not supported', () => {
             assert.throws(() => { sensor.initialize(0, 0); }, TypeError, 'Specified sensor type is not supported');

--- a/test/node-dht-sensor.js
+++ b/test/node-dht-sensor.js
@@ -57,19 +57,21 @@ describe('Read sensor', () => {
         });
     });
     describe('Asynchronously', () => {
-        it('should obtain temperature and humidity', () => {
+        it('should obtain temperature and humidity', (done) => {
             sensor.read(SENSOR_TYPE, GPIO_PIN, (err, temperature, humidity) => {
                 assert.isNull(err);
                 assert.isNumber(temperature);
                 assert.isNumber(humidity);
+                done();
             });
         });
-        it('should fail when invalid sensor type is specified', () => {            
+        it('should fail when invalid sensor type is specified', (done) => {
             sensor.read(3, GPIO_PIN, (err) => {
                 assert.isNotNull(err);
                 assert.throws(() => {
                     assert.ifError(err, 'sensor type is invalid')
                 }, Error, 'sensor type is invalid');
+                done();
             });
         });
     });


### PR DESCRIPTION
As suggested by @kothique, the goal is to provide a new operation mode for using the *node-dht-sensor* -  test mode. When enabled, the library will not communicate with sensor hardware but instead it will provide predefined readout values. This will enable development and testing without an actual sensor connected.

To enable the test mode, fake values must be defined at initialization. In the example below we specify fixed values for temperature equal to 21ºC and humidity equal to 60%.
```javascript
sensor.initialize({
    test : {
        fake: {
            temperature: 21,
            humidity: 60
        }
    }
});
```
After initialization in test mode, we can call the read method as shown below.
```javascript
sensor.read(22, 4, function(err, temperature, humidity) {
    if (!err) {
        console.log('temp: ' + temperature.toFixed(1) + '°C, ' +
            'humidity: ' + humidity.toFixed(1) + '%'
        );
    }
});
```
And the result will be always the fixed readout value defined for the test mode.
```console
$ node examples/fake-test.js 
temp: 21.0°C, humidity: 60.0%
$ node examples/fake-test.js 
temp: 21.0°C, humidity: 60.0%
```
Fixes #77 