### PR TITLE
Whitelist files that should be published

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
     "test": "mocha"
   },
   "main": "./build/Release/node_dht_sensor",
+  "files": [
+    "/src",
+    "/binding.gyp"
+  ],
   "dependencies": {
     "nan": "2.13.2"
   },


### PR DESCRIPTION
Add "files" field to `package.json`. This excludes `examples/` and `test/` from publishing.

https://blog.npmjs.org/post/165769683050/publishing-what-you-mean-to-publish