### PR TITLE
Update ReadWorker to read only if sensor initialized

### DIFF
--- a/src/node-dht-sensor.cpp
+++ b/src/node-dht-sensor.cpp
@@ -44,8 +44,13 @@ public:
   void Execute() override
   {
     sensorMutex.lock();
-    Init();
-    Read();
+
+    if (Init()) {
+      Read();
+    } else {
+      SetError("failed to initialize sensor");
+    }
+
     sensorMutex.unlock();
   }
 
@@ -76,12 +81,14 @@ private:
   float temperature = 0;
   float humidity = 0;
 
-  void Init()
+  bool Init()
   {
     if (!initialized)
     {
       initialized = initialize() == 0;
     }
+
+    return initialized;
   }
 
   void Read()


### PR DESCRIPTION
In the ReadWorker class, check first if the sensor was successfully initialized before attempting to read the sensor, otherwise set error as initialization error.

Fixes #103, #105