### PR TITLE
Increase pull down time for DHT22 sensor to 2.5ms

### DIFF
--- a/src/dht-sensor.cpp
+++ b/src/dht-sensor.cpp
@@ -66,7 +66,7 @@ long readDHT(int type, int pin, float &temperature, float &humidity)
   bcm2835_gpio_write(pin, HIGH);
   usleep(10000);
   bcm2835_gpio_write(pin, LOW);
-  usleep(type == 11 ? 18000 : 800);
+  usleep(type == 11 ? 18000 : 2500);
   bcm2835_gpio_write(pin, HIGH);
   bcm2835_gpio_fsel(pin, BCM2835_GPIO_FSEL_INPT);
 


### PR DESCRIPTION
Based on this comment for DHT11: https://github.com/momenso/node-dht-sensor/issues/67#issuecomment-365784215
And this datasheet: https://www.sparkfun.com/datasheets/Sensors/Temperature/DHT22.pdf#page=6
I tried 1ms (1000 us) pull down time, but it was not enough. A 2ms (2000 us) time seemed to be OK, but to be on the safe side I set this to 2.5ms (2500 us).