### PR TITLE
Set error when reading sensor fails

### DIFF
--- a/examples/promisse.js
+++ b/examples/promisse.js
@@ -1,0 +1,17 @@
+var sensor = require("../lib").promises;
+
+sensor
+  .read(22, 17)
+  .then(
+    function(res) {
+      console.log(
+        `temp: ${res.temperature.toFixed(1)}°C, ` +
+          `humidity: ${res.humidity.toFixed(1)}%`
+      );
+    },
+    function(err) {
+      console.error("Failed to read sensor data:", err);
+    }
+  )
+  .catch(e => console.error("Error: " + e));
+console.log("done");

--- a/src/node-dht-sensor.cpp
+++ b/src/node-dht-sensor.cpp
@@ -111,6 +111,9 @@ private:
       usleep(450000);
     }
     failed = result != 0;
+    if (failed) {
+      SetError("failed to read sensor");
+    }
   }
 };
 


### PR DESCRIPTION
Call `SetError` when no readout value was obtained from reading the sensor.

Not calling `SetError` was causing the promise to not be rejected in case of a failure to read the sensor.